### PR TITLE
fix: use the node modules paths for every resolve request

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -7,6 +7,7 @@ const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
 
+config.resolver.disableHierarchicalLookup = true;
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),


### PR DESCRIPTION
This should force Metro always to resolve libraries using the explicit `nodeModulesPaths` we provide, and in that specific order too. This should allow you to use multiple react/react-dom/react-native versions without breaking them.

~~Note, that this is highly experimental, and we need to check with the Metro team if this is safe to do.~~ According to the [the Metro Resolution Algorithm documentation](https://github.com/facebook/metro/blob/b0c5aacecd102e52b61233211223345351f94fa0/docs/Resolution.md#resolution-algorithm) (step 5), this is exactly what you would need. We want to skip step 5 and always resolve using step 6.